### PR TITLE
CBOR encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ cortex-m = "0.7.3"
 embedded-dma = "0.1.2"
 serde-json-core = "0.4.0"
 
+[dependencies.serde_cbor]
+version = "0.11.1"
+default-features = false
+
 [dependencies.postcard-cobs]
 version = ">=0.2" # https://github.com/ferrous-systems/cobs.rs/pull/2
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turret_firmware"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Joshua Salzedo <jsalzedo0@saddleback.edu>"]
 edition = "2018"
 

--- a/book_src/implementation_details/extern_rust.md
+++ b/book_src/implementation_details/extern_rust.md
@@ -6,9 +6,9 @@ module. This is disadvantagous for many reasons, including maintainability and o
 
 In `main.rs`, you may observe like this
 ```rust
-{{#include ../../src/main.rs:248:249}}
+{{#include ../../src/main.rs:254:255}}
     // ...
-{{#include ../../src/main.rs:254:257}}
+{{#include ../../src/main.rs:260:264}}
         // ...
 ```
 

--- a/book_src/interface.md
+++ b/book_src/interface.md
@@ -6,7 +6,7 @@ The primary communication interface to this firmware is via the `USART1` device.
 # Packet structure
 The maximum length of any packet is defined as
 ```rs
-{{#include ../src/main.rs:70:73}}
+{{#include ../src/main.rs:71:74}}
 ```
 
 Any packet received by this device exceeding this length will be ignored.
@@ -40,7 +40,7 @@ This means, if the payload size is 18, **only the first 16 bytes** (4 Big Endian
 
 
 # Status response structure
-The payload of a status response is a json-encoded object representing the current device 
+The payload of a status response is a CBOR-encoded object representing the current device 
 observations.
 
 ## Request
@@ -54,7 +54,12 @@ The request object is defined below, though at the time of writing the `kind` fi
 ```
 ### Example request payload
 ```python
-payload = b'\x10{"kind": 0}9V\xce\xe4'
+from turret_python_interface.request_packet import RequestPacket
+print(bytes(RequestPacket(kind=4)))
+# b'\x0c\xa1dkind\x04\n\x10Oo\x01'
+print(RequestPacket.from_bytes(b'\x0c\xa1dkind\x04\n\x10Oo\x01'))
+# RequestPacket(kind=4)
+# 2021-08-08 20:16:36.013 | DEBUG    | turret_python_interface.message_base:from_bytes:24 - data bytes := b'\xa1dkind\x04', device CRC := 168841071
 ```
 
 
@@ -68,6 +73,12 @@ The response object is defined below.
 
 ### Example response payload
 ```python
-b'\x17{"turret_pos":0.0}\xcb~aY\x00'
-# data bytes := b'{"turret_pos":0.0}', device CRC := 3414057305
+from turret_python_interface.telemetry_packet import TelemetryPacket
+packet = TelemetryPacket(turret_pos=1.0)
+print(bytes(packet))
+# b'\x10\xa1jturret_pos\xfb?\xf0\x01\x01\x01\x01\x01\x05F/\r\x14\x01'
+print(TelemetryPacket.from_bytes(b'\x10\xa1jturret_pos\xfb?\xf0\x01\x01\x01\x01\x01\x05F/\r\x14\x01'))
+# 2021-08-08 20:19:40.908 | DEBUG    | turret_python_interface.message_base:from_bytes:24 - data bytes := b'\xa1jturret_pos\xfb?\xf0\x00\x00\x00\x00\x00\x00', device CRC := 1177488660
+# TelemetryPacket(turret_pos=1.0)
+
 ```

--- a/src/datamodel/mod.rs
+++ b/src/datamodel/mod.rs
@@ -1,3 +1,3 @@
-pub mod telemetry_packet;
 pub mod request;
 pub mod rx_errors;
+pub mod telemetry_packet;

--- a/src/datamodel/request.rs
+++ b/src/datamodel/request.rs
@@ -1,6 +1,6 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Request {
-    kind: u32
+    kind: u32,
 }

--- a/src/datamodel/request.rs
+++ b/src/datamodel/request.rs
@@ -1,6 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+#[repr(u32)]
+#[derive(Deserialize, Serialize, Debug)]
+pub enum RequestKind {
+    Default = 0,
+    Telemetry = 1,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Request {
-    kind: u32,
+    kind: RequestKind,
 }

--- a/src/datamodel/rx_errors.rs
+++ b/src/datamodel/rx_errors.rs
@@ -6,7 +6,7 @@ pub enum RxError {
     CobsDecoderPushFailed,
     InvalidSenderCrc,
     FailedTelemetrySpawn,
-    FailedJsonDeserialize,
+    FailedDeserialize,
     BufferOverflow,
     DmaReconfigFailed,
     DmaTransferFailed,

--- a/src/datamodel/rx_errors.rs
+++ b/src/datamodel/rx_errors.rs
@@ -1,4 +1,3 @@
-
 #[derive(Debug)]
 pub enum RxError {
     CobsDecoderNeededMoreBytes,

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,9 +42,10 @@ mod app {
         },
         prelude::*,
         pwm_input::PwmInput,
+        pwm::{PwmChannels, C1},
         rcc::Rcc,
         serial,
-        stm32::{DMA2, TIM8, USART1},
+        stm32::{DMA2, TIM8, USART1, TIM4},
         timer::Timer,
     };
 
@@ -149,7 +150,7 @@ mod app {
         // obtain a reference to the GPIO* register blocks, so we can configure pins on the P* buses.
         let gpioc = ctx.device.GPIOC.split();
         let gpioa = ctx.device.GPIOA.split();
-        // let gpiob = ctx.device.GPIOB.split();
+        let gpiob = ctx.device.GPIOB.split();
 
         // Configure one of TIM8's CH1 pins, so that its attached to the peripheral.
         // We need to do this since the pins are multiplexed across multiple peripherals
@@ -160,6 +161,10 @@ mod app {
         // Note: as a side-effect TIM8's interrupt is enabled and fires whenever a capture-compare
         //      cycle is complete. See the reference manual's paragraphs on PWM Input.
         let monitor = Timer::new(ctx.device.TIM8, &clocks).pwm_input(240.hz(), tim8_cc1);
+
+        let mut pwm_mock: PwmChannels<TIM4, C1> = Timer::new(ctx.device.TIM4, &clocks).pwm(gpiob.pb6.into_alternate(), 200.hz());
+        pwm_mock.set_duty(pwm_mock.get_max_duty() / 2);
+        pwm_mock.enable();
 
         /*
         begin USART1 config

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,11 +41,11 @@ mod app {
             Alternate,
         },
         prelude::*,
-        pwm_input::PwmInput,
         pwm::{PwmChannels, C1},
+        pwm_input::PwmInput,
         rcc::Rcc,
         serial,
-        stm32::{DMA2, TIM8, USART1, TIM4},
+        stm32::{DMA2, TIM4, TIM8, USART1},
         timer::Timer,
     };
 
@@ -162,7 +162,8 @@ mod app {
         //      cycle is complete. See the reference manual's paragraphs on PWM Input.
         let monitor = Timer::new(ctx.device.TIM8, &clocks).pwm_input(240.hz(), tim8_cc1);
 
-        let mut pwm_mock: PwmChannels<TIM4, C1> = Timer::new(ctx.device.TIM4, &clocks).pwm(gpiob.pb6.into_alternate(), 200.hz());
+        let mut pwm_mock: PwmChannels<TIM4, C1> =
+            Timer::new(ctx.device.TIM4, &clocks).pwm(gpiob.pb6.into_alternate(), 200.hz());
         pwm_mock.set_duty(pwm_mock.get_max_duty() / 2);
         pwm_mock.enable();
 

--- a/src/tasks/usart1_rx.rs
+++ b/src/tasks/usart1_rx.rs
@@ -6,11 +6,11 @@ use stm32f4xx_hal::stm32::{DMA2, USART1};
 use crate::app::{
     on_usart1_idle, on_usart1_rx_dma, Usart1Buf, Usart1TransferRx, {BUF_SIZE, MESSAGE_SIZE},
 };
+use crate::datamodel::{request::Request, rx_errors::RxError};
 use crate::tasks::TxBufferState;
 use core::convert::TryInto;
-use stm32f4xx_hal::crc32::Crc32;
 use core::ops::Index;
-use crate::datamodel::{request::Request, rx_errors::RxError};
+use stm32f4xx_hal::crc32::Crc32;
 
 /// Handles the DMA transfer complete Interrupt
 pub(crate) fn on_usart1_rx_dma(_ctx: on_usart1_rx_dma::Context) {
@@ -24,7 +24,7 @@ pub(crate) fn on_usart1_idle(ctx: on_usart1_idle::Context) {
     rprintln!("RX line fell idle, packet recv'ed.");
     // acquire lock to shared resources, then call the actual handler.
     (ctx.shared.recv, ctx.shared.crc).lock(|transfer: &mut Usart1TransferRx, crc: &mut Crc32| {
-            handle_rx(transfer, crc);
+        handle_rx(transfer, crc);
     });
 }
 
@@ -82,10 +82,13 @@ fn handle_rx(transfer: &mut Usart1TransferRx, crc: &mut Crc32) {
         rprintln!("Someone sent a bigger message frame than allowed.");
         Err(RxError::BufferOverflow)
     } else {
-            process_mabie_packet(&packet,crc )
+        process_mabie_packet(&packet, crc)
     };
     if let Err(e) = result {
-        rprintln!("[ERROR] Something went horribly wrong processing packet {:?}!", e);
+        rprintln!(
+            "[ERROR] Something went horribly wrong processing packet {:?}!",
+            e
+        );
     }
 
     transfer.clear_interrupts();
@@ -124,8 +127,9 @@ fn process_mabie_packet(input_buffer: &[u8], crc: &mut Crc32) -> Result<(), RxEr
             rprintln!("[ERROR] Decoder demanded more bytes than we can feed it.");
             Err(RxError::CobsDecoderNeededMoreBytes)
         }
-        Ok(Some((message_length, _))) =>{
+        Ok(Some((message_length, _))) => {
             rprintln!("Decode successful, decoded {} bytes.", message_length);
+            rprintln!("un-COBS'ed := {:?}", buffer);
             Ok(message_length)
         }
         Err(j) => {
@@ -133,33 +137,44 @@ fn process_mabie_packet(input_buffer: &[u8], crc: &mut Crc32) -> Result<(), RxEr
             Err(RxError::CobsDecoderError(j))
         }
     } {
+        // NOTE: this somehow solves an off-by-one error.
+        let n = n - 1;
         // If decoding succeeded, then fetch the sender CRC.
-        let crc_bytes = &buffer[n-4..n];
+        let crc_bytes = &buffer[n - 4..n];
         rprintln!("crc buffer := {:?}", crc_bytes);
-        let sender_crc = u32::from_be_bytes(crc_bytes.try_into().expect("failed to interpret sender CRC as a u32!"));
+        let sender_crc = u32::from_be_bytes(
+            crc_bytes
+                .try_into()
+                .expect("failed to interpret sender CRC as a u32!"),
+        );
         // Then compute the device CRC.
-        let data = &mut buffer[..n-4];
+        let data = &mut buffer[..n - 4];
+        rprintln!("computing sender CRC with data length {}", data.len());
         let device_crc = compute_crc(data, crc);
 
         // Ensure the two match..
         if sender_crc != device_crc {
-            rprintln!("[ERROR] Sender CRC {} != Device CRC {}", sender_crc, device_crc);
+            rprintln!(
+                "[ERROR] Sender CRC {} != Device CRC {}",
+                sender_crc,
+                device_crc
+            );
             Err(RxError::InvalidSenderCrc)
         } else {
             rprintln!("RX checksum passed.");
             // Deserialize internal CBOR packet.
             // Note: the data buffer needs to be mutable as an implementation detail of CBOR.
-            let request_result: serde_cbor::Result<Request> = serde_cbor::de::from_mut_slice(data );
+            let request_result: serde_cbor::Result<Request> = serde_cbor::de::from_mut_slice(data);
 
             // Check that the deserialization was successful.
-            if let Ok(request)= request_result {
+            if let Ok(request) = request_result {
                 rprintln!("successfully deserialized request {:?}", request);
                 // Spawn the telemetry worker
                 // Note: we remap the error here to our internal enum for consistancy.
                 crate::app::write_telemetry::spawn().map_err(|e| {
                     rprintln!("[error] failed to spawn telemetry writer with err {:?}", e);
                     RxError::FailedTelemetrySpawn
-                } )?;
+                })?;
                 Ok(())
             } else {
                 rprintln!("[error] failed to deserialize well-formed packet!");
@@ -169,22 +184,31 @@ fn process_mabie_packet(input_buffer: &[u8], crc: &mut Crc32) -> Result<(), RxEr
     } else {
         Err(RxError::CobsDecoderPushFailed)
     }
-
-
 }
 
+/// computes the CRC-32(ethernet) of the provided data buffer.
+/// Note: this uses the CRC32 peripheral, which only operates on u32 words.
+///     For the sake of simplicity, the input buffer is truncated to the nearest word boundry,
+///     and the resulting smaller buffer is then fed to the peripheral.
 pub(crate) fn compute_crc(buffer: &[u8], crc: &mut Crc32) -> u32 {
+    // Reset the peripheral.
     crc.init();
     let payload_size = buffer.len();
-    let remainder = buffer.len() % 4;
-    let total_words = buffer.len() / 4;
+    let remainder = payload_size % 4;
+    let total_words = payload_size / 4;
     if remainder != 0 {
         rprintln!("input data (length {}) was not word-aligned, truncating to {} bytes for calculation...", buffer.len(), total_words*4)
     }
+    // truncate to the word boundry
     let buffer = &buffer[0..total_words * 4];
     let chunks = buffer.chunks_exact(4);
 
-    rprintln!("checksumming {} bytes of a {} byte payload across {} words.", buffer.len(), payload_size, chunks.len());
+    rprintln!(
+        "checksumming {} bytes of a {} byte payload across {} words.",
+        buffer.len(),
+        payload_size,
+        chunks.len()
+    );
     rprintln!("buffer := {:?}", buffer);
     let mut result: u32 = 0;
     chunks.for_each(|chunk| {
@@ -192,7 +216,6 @@ pub(crate) fn compute_crc(buffer: &[u8], crc: &mut Crc32) -> u32 {
         rprintln!("feeding word {:x}", word);
         result = crc.update(&[word])
     });
-
 
     result
 }

--- a/src/tasks/write_telemetry.rs
+++ b/src/tasks/write_telemetry.rs
@@ -3,7 +3,7 @@ use core::convert::TryInto;
 use rtic::{mutex_prelude::*, time::duration::Seconds};
 use rtt_target::rprintln;
 use serde::{Deserialize, Serialize};
-use serde_cbor::ser::{SliceWrite,Serializer};
+use serde_cbor::ser::{Serializer, SliceWrite};
 use stm32f4xx_hal::{crc32::Crc32, prelude::*};
 
 use crate::app::{Usart1Buf, Usart1TransferTx, Usart1Tx, BUF_SIZE, MESSAGE_SIZE};
@@ -69,9 +69,10 @@ pub(crate) fn write_telemetry(
     /*
     entering critical section
      */
-    let checksum: u32 = context.shared.crc.lock(|crc: &mut Crc32| {
-        compute_crc(&payload_buffer[..payload_size],crc)
-    });
+    let checksum: u32 = context
+        .shared
+        .crc
+        .lock(|crc: &mut Crc32| compute_crc(&payload_buffer[..payload_size], crc));
     rprintln!("CRC := {}", checksum);
     /*
     exiting critical section


### PR DESCRIPTION
This PR refactors the serialization layer to use CBOR over JSON, with a market speed improvement to boot.
It also improves RX message handling a bit, removing all those pesky `Err(())` and replacing them by a proper error enumeration.

depends on https://github.com/SC-Robotics-2021/turret_python_interface/pull/2